### PR TITLE
Use a single stage since stages share no storage between each other.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,7 +6,7 @@ python:
   
 jobs:
   include:
-    - stage: install
-      script: test/travis/install.sh
     - stage: lint
-      script: test/travis/lint.sh
+      script:
+        - test/travis/install.sh
+        - test/travis/lint.sh


### PR DESCRIPTION
Travis stages do not share storage between stages (different VMs) so let's run the install script and lint script in the same stage.