### PR TITLE
Extend container with `command` and `args` fields.

### DIFF
--- a/charts/cronjob/Chart.yaml
+++ b/charts/cronjob/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 description: Helm chart for deploying an instance of a cronjob on a K8s cluster.
 name: cronjob
-version: 1.0.1
+version: 1.1.0
 maintainers:
   - name: heshamMassoud

--- a/charts/cronjob/README.md
+++ b/charts/cronjob/README.md
@@ -53,7 +53,8 @@ The chart can be customized using the following configurable parameters:
 | `image.repository` | docker image repository | `commercetools/commercetools-email-retry-processor` |
 | `image.tag` | docker image tag | `1.0.0` |
 | `image.pullPolicy` | docker image pull policy | `IfNotPresent` |
-| `image.command` | docker command Entrypoint array| `['cmd1', 'cmd2']` |
+| `image.command` | docker Entrypoint command array| `[]` |
+| `image.args` | docker Entrypoint command arguments array| `[]` |
 | `resources` | resource requests and limits | `{}` |
 | `schedule` | schedule of the cronjob | `*/1 * * * *` |
 | `nonSensitiveEnvs` | non sensitive environment variables | |

--- a/charts/cronjob/README.md
+++ b/charts/cronjob/README.md
@@ -53,7 +53,7 @@ The chart can be customized using the following configurable parameters:
 | `image.repository` | docker image repository | `commercetools/commercetools-email-retry-processor` |
 | `image.tag` | docker image tag | `1.0.0` |
 | `image.pullPolicy` | docker image pull policy | `IfNotPresent` |
-| `image.command` | docker command Entrypoint array| `[]` |
+| `image.command` | docker command Entrypoint array| `['cmd1', 'cmd2']` |
 | `resources` | resource requests and limits | `{}` |
 | `schedule` | schedule of the cronjob | `*/1 * * * *` |
 | `nonSensitiveEnvs` | non sensitive environment variables | |

--- a/charts/cronjob/README.md
+++ b/charts/cronjob/README.md
@@ -53,8 +53,8 @@ The chart can be customized using the following configurable parameters:
 | `image.repository` | docker image repository | `commercetools/commercetools-email-retry-processor` |
 | `image.tag` | docker image tag | `1.0.0` |
 | `image.pullPolicy` | docker image pull policy | `IfNotPresent` |
-| `image.command` | docker Entrypoint command array| `[]` |
-| `image.args` | docker Entrypoint command arguments array| `[]` |
+| `image.command` | docker Entrypoint command array. The docker image's `ENTRYPOINT` is used if this is not provided.| `[]` |
+| `image.args` | docker Entrypoint command arguments array. The docker image's `CMD` is used if this is not provided. | `[]` |
 | `resources` | resource requests and limits | `{}` |
 | `schedule` | schedule of the cronjob | `*/1 * * * *` |
 | `nonSensitiveEnvs` | non sensitive environment variables | |

--- a/charts/cronjob/README.md
+++ b/charts/cronjob/README.md
@@ -53,6 +53,7 @@ The chart can be customized using the following configurable parameters:
 | `image.repository` | docker image repository | `commercetools/commercetools-email-retry-processor` |
 | `image.tag` | docker image tag | `1.0.0` |
 | `image.pullPolicy` | docker image pull policy | `IfNotPresent` |
+| `image.command` | docker command Entrypoint array| `[]` |
 | `resources` | resource requests and limits | `{}` |
 | `schedule` | schedule of the cronjob | `*/1 * * * *` |
 | `nonSensitiveEnvs` | non sensitive environment variables | |

--- a/charts/cronjob/templates/cronjob.yaml
+++ b/charts/cronjob/templates/cronjob.yaml
@@ -25,10 +25,10 @@ spec:
             - name: {{ .Chart.Name }}
               image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
               imagePullPolicy: {{ .Values.image.pullPolicy }}
-              command: [{{- range $index, $element := .Values.image.command}}
-                          {{- if $index}},{{- end}}
-                          {{- $element | quote}}
-                        {{- end}}]
+              command:
+{{ toYaml .Values.image.command | indent 16 }}
+              args:
+{{ toYaml .Values.image.args | indent 16 }}
               # Inject (non sensitive) environment variables from the `Values` config.
               env:
               {{- range $key, $val := .Values.nonSensitiveEnvs }}

--- a/charts/cronjob/templates/cronjob.yaml
+++ b/charts/cronjob/templates/cronjob.yaml
@@ -25,6 +25,10 @@ spec:
             - name: {{ .Chart.Name }}
               image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
               imagePullPolicy: {{ .Values.image.pullPolicy }}
+              command: [{{- range $index, $element := .Values.image.command}}
+                          {{- if $index}},{{- end}}
+                          {{- $element | quote}}
+                        {{- end}}]
               # Inject (non sensitive) environment variables from the `Values` config.
               env:
               {{- range $key, $val := .Values.nonSensitiveEnvs }}

--- a/charts/cronjob/values.yaml
+++ b/charts/cronjob/values.yaml
@@ -2,7 +2,7 @@ image:
   repository: 'commercetools/commercetools-email-retry-processor'
   tag: '1.0.0'
   pullPolicy: 'IfNotPresent'
-  command: []
+  command: ['cmd1', 'cmd2']
 
 ## specifies the resource requests and limits
 ## ref: http://kubernetes.io/docs/user-guide/compute-resources/

--- a/charts/cronjob/values.yaml
+++ b/charts/cronjob/values.yaml
@@ -2,6 +2,7 @@ image:
   repository: 'commercetools/commercetools-email-retry-processor'
   tag: '1.0.0'
   pullPolicy: 'IfNotPresent'
+  command: []
 
 ## specifies the resource requests and limits
 ## ref: http://kubernetes.io/docs/user-guide/compute-resources/

--- a/charts/cronjob/values.yaml
+++ b/charts/cronjob/values.yaml
@@ -2,7 +2,7 @@ image:
   repository: 'commercetools/commercetools-email-retry-processor'
   tag: '1.0.0'
   pullPolicy: 'IfNotPresent'
-  command: ['cmd1', 'cmd2']
+  command: [] #specifies the entry point commands to the docker container.
 
 ## specifies the resource requests and limits
 ## ref: http://kubernetes.io/docs/user-guide/compute-resources/

--- a/charts/cronjob/values.yaml
+++ b/charts/cronjob/values.yaml
@@ -2,9 +2,9 @@ image:
   repository: 'commercetools/commercetools-email-retry-processor'
   tag: '1.0.0'
   pullPolicy: 'IfNotPresent'
-  # specifies the entry point command to the docker container.
+  # specifies the entry point command to the docker container. The docker image's `ENTRYPOINT` is used if this is not provided.
   command: []
-  # specifies the arguments to the entry point to the docker container.
+  # specifies the arguments to the entry point to the docker container. The docker image's `CMD` is used if this is not provided.
   args: []
 
 ## specifies the resource requests and limits

--- a/charts/cronjob/values.yaml
+++ b/charts/cronjob/values.yaml
@@ -2,7 +2,8 @@ image:
   repository: 'commercetools/commercetools-email-retry-processor'
   tag: '1.0.0'
   pullPolicy: 'IfNotPresent'
-  command: [] #specifies the entry point commands to the docker container.
+  # specifies the entry point commands to the docker container.
+  command: []
 
 ## specifies the resource requests and limits
 ## ref: http://kubernetes.io/docs/user-guide/compute-resources/

--- a/charts/cronjob/values.yaml
+++ b/charts/cronjob/values.yaml
@@ -2,8 +2,10 @@ image:
   repository: 'commercetools/commercetools-email-retry-processor'
   tag: '1.0.0'
   pullPolicy: 'IfNotPresent'
-  # specifies the entry point commands to the docker container.
+  # specifies the entry point command to the docker container.
   command: []
+  # specifies the arguments to the entry point to the docker container.
+  args: []
 
 ## specifies the resource requests and limits
 ## ref: http://kubernetes.io/docs/user-guide/compute-resources/


### PR DESCRIPTION
1. Add `command` and `args` field to container resource. 
2. Add [documentation](https://github.com/commercetools/k8s-charts/pull/7/files#diff-8e08fd01be5542564dd7fb0c96484c92) for new configurable value.
2. [Bump chart version](https://github.com/commercetools/k8s-charts/commit/757eaa194fb9d3ad08401f21d6f43ee9d1e3b4ed).