### PR TITLE
Use fullname as chart name.

### DIFF
--- a/charts/cronjob/Chart.yaml
+++ b/charts/cronjob/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 description: Helm chart for deploying an instance of a cronjob on a K8s cluster.
 name: cronjob
-version: 1.0.1
+version: 1.0.2
 maintainers:
   - name: heshamMassoud

--- a/charts/cronjob/templates/_helpers.tpl
+++ b/charts/cronjob/templates/_helpers.tpl
@@ -3,7 +3,25 @@
 Expand the name of the chart.
 */}}
 {{- define "cronjob.name" -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+
+{{/*
+Create a default fully qualified app name.
+We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
+If release name contains chart name it will be used as a full name.
+*/}}
+{{- define "cronjob.fullname" -}}
+{{- if .Values.fullnameOverride -}}
+{{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" -}}
+{{- else -}}
+{{- $name := default .Chart.Name .Values.nameOverride -}}
+{{- if contains $name .Release.Name -}}
 {{- .Release.Name | trunc 63 | trimSuffix "-" -}}
+{{- else -}}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+{{- end -}}
 {{- end -}}
 
 {{/*

--- a/charts/cronjob/templates/cronjob.yaml
+++ b/charts/cronjob/templates/cronjob.yaml
@@ -1,7 +1,7 @@
 apiVersion: batch/v1beta1
 kind: CronJob
 metadata:
-  name: {{ template "cronjob.name" . }}
+  name: {{ template "cronjob.fullname" . }}
   labels:
     app: {{ template "cronjob.name" . }}
     chart: {{ template "cronjob.chart" . }}
@@ -35,7 +35,7 @@ spec:
               # them from the related Secret object. This is an extra measure of security
               # to avoid having credentials displayed in plain text in the template file.
               # https://kubernetes.io/docs/concepts/configuration/secret/
-              {{- $chartName := include "cronjob.name" . -}}
+              {{- $chartName := include "cronjob.fullname" . -}}
               {{- range $key, $val := .Values.sensitiveEnvs }}
               - name: {{ $key }}
                 valueFrom:

--- a/charts/cronjob/templates/secrets.yaml
+++ b/charts/cronjob/templates/secrets.yaml
@@ -3,7 +3,7 @@
 apiVersion: v1
 kind: Secret
 metadata:
-  name: {{ template "cronjob.name" . }}-secret
+  name: {{ template "cronjob.fullname" . }}-secret
   labels:
     app: {{ template "cronjob.name" . }}
     chart: {{ template "cronjob.chart" . }}


### PR DESCRIPTION
Switch to using named tempate "fullname" for generating chart name value (as used in the sample chart when creating a new chart with `helm create my-chart`).