### PR TITLE
Add isOnDemand variable for ondemand jobs

### DIFF
--- a/charts/cronjob/Chart.yaml
+++ b/charts/cronjob/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 description: Helm chart for deploying an instance of a cronjob on a K8s cluster.
 name: cronjob
-version: 1.3.0
+version: 1.4.0
 maintainers:
   - name: heshamMassoud

--- a/charts/cronjob/Chart.yaml
+++ b/charts/cronjob/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 description: Helm chart for deploying an instance of a cronjob on a K8s cluster.
 name: cronjob
-version: 1.4.0
+version: 1.7.0
 maintainers:
   - name: heshamMassoud

--- a/charts/cronjob/README.md
+++ b/charts/cronjob/README.md
@@ -57,6 +57,7 @@ The chart can be customized using the following configurable parameters:
 | `image.args` | docker Entrypoint command arguments array. The docker image's `CMD` is used if this is not provided. | `[]` |
 | `resources` | resource requests and limits | `{}` |
 | `schedule` | schedule of the cronjob | `*/1 * * * *` |
+| `isOnDemand` | should suspend cronjob at start and label it with `ondemand:true` label | `false` |
 | `startingDeadlineSeconds` | By default if cron job fails to trigger 100 times it's scheduled job (due to jobs's unexpectedly long run or temporal network error) then cron job gets stuck and do not schedule new jobs anymore. This setting ensures that failed job executions are only counted within last 600 seconds and thus not reaching the limit. For cron schedules below 1 minutes one should consider to override default with lower value. More info: https://github.com/kubernetes/kubernetes/pull/39608 | 600 |
 | `nonSensitiveEnvs` | non sensitive environment variables | |
 | `sensitiveEnvs` | sensitive environment variables | |

--- a/charts/cronjob/README.md
+++ b/charts/cronjob/README.md
@@ -57,7 +57,7 @@ The chart can be customized using the following configurable parameters:
 | `image.args` | docker Entrypoint command arguments array. The docker image's `CMD` is used if this is not provided. | `[]` |
 | `resources` | resource requests and limits | `{}` |
 | `schedule` | schedule of the cronjob | `*/1 * * * *` |
-| `runOnDemandOnly` | should suspend cronjob at start and label it with `ondemand:true` label | `false` |
+| `runOnDemandOnly` | If set to `true` cron job will be created as suspended which ensures that it will not schedule any jobs but on the other hand would allow to trigger jobs manually based on cron job specification - for example through Kubernetes API | `false` |
 | `suspend` | should suspend cronjob at start | `false` |
 | `startingDeadlineSeconds` | By default if cron job fails to trigger 100 times it's scheduled job (due to jobs's unexpectedly long run or temporal network error) then cron job gets stuck and do not schedule new jobs anymore. This setting ensures that failed job executions are only counted within last 600 seconds and thus not reaching the limit. For cron schedules below 1 minutes one should consider to override default with lower value. More info: https://github.com/kubernetes/kubernetes/pull/39608 | 600 |
 | `nonSensitiveEnvs` | non sensitive environment variables | |

--- a/charts/cronjob/README.md
+++ b/charts/cronjob/README.md
@@ -57,7 +57,8 @@ The chart can be customized using the following configurable parameters:
 | `image.args` | docker Entrypoint command arguments array. The docker image's `CMD` is used if this is not provided. | `[]` |
 | `resources` | resource requests and limits | `{}` |
 | `schedule` | schedule of the cronjob | `*/1 * * * *` |
-| `isOnDemand` | should suspend cronjob at start and label it with `ondemand:true` label | `false` |
+| `runOnDemandOnly` | should suspend cronjob at start and label it with `ondemand:true` label | `false` |
+| `suspend` | should suspend cronjob at start | `false` |
 | `startingDeadlineSeconds` | By default if cron job fails to trigger 100 times it's scheduled job (due to jobs's unexpectedly long run or temporal network error) then cron job gets stuck and do not schedule new jobs anymore. This setting ensures that failed job executions are only counted within last 600 seconds and thus not reaching the limit. For cron schedules below 1 minutes one should consider to override default with lower value. More info: https://github.com/kubernetes/kubernetes/pull/39608 | 600 |
 | `nonSensitiveEnvs` | non sensitive environment variables | |
 | `sensitiveEnvs` | sensitive environment variables | |

--- a/charts/cronjob/templates/cronjob.yaml
+++ b/charts/cronjob/templates/cronjob.yaml
@@ -9,7 +9,9 @@ metadata:
     heritage: {{ .Release.Service }}
 spec:
   schedule: {{ .Values.schedule | quote }}
-  {{- if eq .Values.isOnDemand }}
+  {{- if .Values.runOnDemandOnly }}
+  suspend: true
+  {{ else if .Values.suspend }}
   suspend: true
   {{- end}}
   startingDeadlineSeconds: {{ .Values.startingDeadlineSeconds }}
@@ -23,10 +25,8 @@ spec:
           labels:
             app: {{ template "cronjob.name" . }}
             release: {{ .Release.Name }}
-            {{- if eq .Values.isOnDemand }}
+            {{- if .Values.runOnDemandOnly }}
             ondemand: "true"
-            {{ else }}
-            ondemand: "false"
             {{- end}}
           annotations:
             checksum/config: {{ include (print $.Template.BasePath "/secrets.yaml") . | sha256sum }}

--- a/charts/cronjob/templates/cronjob.yaml
+++ b/charts/cronjob/templates/cronjob.yaml
@@ -26,7 +26,7 @@ spec:
             app: {{ template "cronjob.name" . }}
             release: {{ .Release.Name }}
             {{- if .Values.runOnDemandOnly }}
-            ondemand: "true"
+            runOnDemandOnly: "true"
             {{- end}}
           annotations:
             checksum/config: {{ include (print $.Template.BasePath "/secrets.yaml") . | sha256sum }}

--- a/charts/cronjob/templates/cronjob.yaml
+++ b/charts/cronjob/templates/cronjob.yaml
@@ -9,7 +9,7 @@ metadata:
     heritage: {{ .Release.Service }}
 spec:
   schedule: {{ .Values.schedule | quote }}
-  {{- if eq .Values.isOnDemand true}}
+  {{- if eq .Values.isOnDemand }}
   suspend: true
   {{- end}}
   startingDeadlineSeconds: {{ .Values.startingDeadlineSeconds }}
@@ -23,7 +23,7 @@ spec:
           labels:
             app: {{ template "cronjob.name" . }}
             release: {{ .Release.Name }}
-            {{- if eq .Values.isOnDemand true}}
+            {{- if eq .Values.isOnDemand }}
             ondemand: "true"
             {{ else }}
             ondemand: "false"

--- a/charts/cronjob/templates/cronjob.yaml
+++ b/charts/cronjob/templates/cronjob.yaml
@@ -9,6 +9,9 @@ metadata:
     heritage: {{ .Release.Service }}
 spec:
   schedule: {{ .Values.schedule | quote }}
+  {{- if eq .Values.isOnDemand true}}
+  suspend: true
+  {{- end}}
   startingDeadlineSeconds: {{ .Values.startingDeadlineSeconds }}
   concurrencyPolicy: {{ .Values.concurrency }}
   successfulJobsHistoryLimit: {{ .Values.successfulJobsHistoryLimit }}
@@ -20,6 +23,11 @@ spec:
           labels:
             app: {{ template "cronjob.name" . }}
             release: {{ .Release.Name }}
+            {{- if eq .Values.isOnDemand true}}
+            ondemand: "true"
+            {{ else }}
+            ondemand: "false"
+            {{- end}}
           annotations:
             checksum/config: {{ include (print $.Template.BasePath "/secrets.yaml") . | sha256sum }}
         spec:

--- a/charts/cronjob/values.yaml
+++ b/charts/cronjob/values.yaml
@@ -23,8 +23,11 @@ resources: {}
 # as schedule time of its jobs to be created and executed
 schedule: '*/1 * * * *'
 
+# suspends cronjob at start
+suspend: false
+
 # on-demand jobs are suspended at start and labeled with ondemand:true label
-isOnDemand: false
+runOnDemandOnly: false
 
 # By default if cron job fails to trigger 100 times it's scheduled job
 # (due to jobs's unexpectedly long run or temporal network error) then cron

--- a/charts/cronjob/values.yaml
+++ b/charts/cronjob/values.yaml
@@ -23,6 +23,9 @@ resources: {}
 # as schedule time of its jobs to be created and executed
 schedule: '*/1 * * * *'
 
+# on-demand jobs are suspended at start and labeled with ondemand:true label
+isOnDemand: false
+
 # By default if cron job fails to trigger 100 times it's scheduled job
 # (due to jobs's unexpectedly long run or temporal network error) then cron
 # job gets stuck and do not schedule new jobs anymore. Below setting ensures

--- a/charts/cronjob/values.yaml
+++ b/charts/cronjob/values.yaml
@@ -26,7 +26,7 @@ schedule: '*/1 * * * *'
 # suspends cronjob at start
 suspend: false
 
-# on-demand jobs are suspended at start and labeled with ondemand:true label
+# on-demand jobs are suspended at start and labeled with runOnDemandOnly:true label
 runOnDemandOnly: false
 
 # By default if cron job fails to trigger 100 times it's scheduled job


### PR DESCRIPTION
This PR adds a `isOnDemand` variable which in case it is set to `true` label job with `ondemand:"true"` label and suspend it at the start