### PR TITLE
Change service type of public service to NodePort

### DIFF
--- a/charts/public-service/Chart.yaml
+++ b/charts/public-service/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: public-service
 description: Helm chart for deploying an instance of a publicly available service on a K8s cluster (via HTTP from outside the cluster).
-version: 1.0.3
+version: 1.0.4
 maintainers:
   - name: heshamMassoud

--- a/charts/public-service/values.yaml
+++ b/charts/public-service/values.yaml
@@ -7,7 +7,7 @@ image:
 
 replicaCount: 1
 
-# specifies that application is accessible outside the container
+# specifies that application is accessible outside the cluster
 service:
   type: 'NodePort'
 

--- a/charts/public-service/values.yaml
+++ b/charts/public-service/values.yaml
@@ -7,7 +7,7 @@ image:
 
 replicaCount: 1
 
-# specifies that application is accessible outside of the container
+# specifies that application is accessible outside the container
 service:
   type: 'NodePort'
 

--- a/charts/public-service/values.yaml
+++ b/charts/public-service/values.yaml
@@ -8,8 +8,7 @@ image:
 replicaCount: 1
 
 service:
-  type: 'ClusterIP'
-  port: 80
+  type: 'NodePort'
 
 ## specifies the port to access the application within the container.
 containerPort: 8080

--- a/charts/public-service/values.yaml
+++ b/charts/public-service/values.yaml
@@ -7,6 +7,7 @@ image:
 
 replicaCount: 1
 
+# specifies that application is accessible outside of the container
 service:
   type: 'NodePort'
 


### PR DESCRIPTION
Since public service usually should be accessible outside the cluster, service type of it was changed to `NodePort`