### PR TITLE
fix public service "default port" bug

### DIFF
--- a/charts/public-service/Chart.yaml
+++ b/charts/public-service/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: public-service
 description: Helm chart for deploying an instance of a publicly available service on a K8s cluster (via HTTP from outside the cluster).
-version: 1.0.4
+version: 1.0.5
 maintainers:
   - name: heshamMassoud

--- a/charts/public-service/values.yaml
+++ b/charts/public-service/values.yaml
@@ -10,6 +10,7 @@ replicaCount: 1
 # specifies that application is accessible outside the cluster
 service:
   type: 'NodePort'
+  port: 80
 
 ## specifies the port to access the application within the container.
 containerPort: 8080


### PR DESCRIPTION
Service should have a port between 1 and 65535. Default value is 0.
That's why it should be set.