### PR TITLE
Fix helm related float bug when using -set option

### DIFF
--- a/ci-examples/travis-gke/scripts/helm-upgrade.sh
+++ b/ci-examples/travis-gke/scripts/helm-upgrade.sh
@@ -23,5 +23,5 @@ helm upgrade --install "$APPLICATION_NAME" --namespace "$ENVIRONMENT_NAME" \
     $(execOptionIfFileExistsAndIsReadable "$COMMON_INSENSITIVE_ENVS_FILE" "-f") \
     $(execOptionIfFileExistsAndIsReadable "$ENVIRONMENT_SPECIFIC_INSENSITIVE_ENVS_FILE" "-f") \
     $(execOptionIfFileExistsAndIsReadable "$SENSITIVE_ENVS_FILE" "-f") \
-    $( if [[ -n $IMAGE_TAG ]]; then printf "%s" "--set image.tag=${IMAGE_TAG}"; fi ) \
+    $( if [[ -n $IMAGE_TAG ]]; then printf "%s" "--set-string image.tag=${IMAGE_TAG}"; fi ) \
     "$CHARTS_DIR/$HELM_CHART_TEMPLATE_NAME/"


### PR DESCRIPTION
## Description
In the `travis.yml` file we usually declare a global environment variable `COMMIT_HASH` as a first 8 characters of the commit hash.
Although often there is at least 1 non-numeric character in first 8 characters of a commit hash, sometimes it happens to be a valid number like `**44038821**8fb11dcb6649b03f69d0eb3010260cd1`.
Later we create an image with a tag which is the truncated commit hash and put to the Container Registry. Then we use this tag to push an image using Helm.

Because of the [bug in Helm](https://github.com/kubernetes/helm/issues/1707) `--set image.tag="$COMMIT_HASH"` will be processed as a valid float type variable and become `4.4038821e+07` and later will end up as an error on Kubernetes
```
couldn't parse image reference "XXX:4.4038821e+07": invalid reference format.
Error: InvalidImageName
```
In version 2.9.0 to fix this problem Helm introduced another flag to pass a string called `--set-string`.

## Solution
In this PR I change Helm version to the latest one 2.9.1 and replace `--set` with `--set-string` in `helm upgrade` command