### PR TITLE
Update k8s resource versions

### DIFF
--- a/charts/public-service/Chart.yaml
+++ b/charts/public-service/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: public-service
 description: Helm chart for deploying an instance of a publicly available service on a K8s cluster (via HTTP from outside the cluster).
-version: 1.0.5
+version: 1.0.6
 maintainers:
   - name: heshamMassoud

--- a/charts/public-service/templates/deployment.yaml
+++ b/charts/public-service/templates/deployment.yaml
@@ -1,4 +1,4 @@
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: {{ template "public-service.fullname" . }}

--- a/charts/public-service/templates/ingress.yaml
+++ b/charts/public-service/templates/ingress.yaml
@@ -1,7 +1,7 @@
 {{- if .Values.ingress.enabled -}}
 {{- $fullName := include "public-service.fullname" . -}}
 {{- $ingressPath := .Values.ingress.path -}}
-apiVersion: extensions/v1beta1
+apiVersion: networking.k8s.io/v1beta1
 kind: Ingress
 metadata:
   name: {{ $fullName }}


### PR DESCRIPTION
Resource versions we were using before are now deprecated. See https://kubernetes.io/blog/2019/07/18/api-deprecations-in-1-16/