### PR TITLE
Add new affinity flag to public service deployment.yaml

### DIFF
--- a/charts/public-service/Chart.yaml
+++ b/charts/public-service/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: public-service
 description: Helm chart for deploying an instance of a publicly available service on a K8s cluster (via HTTP from outside the cluster).
-version: 1.0.6
+version: 1.0.7
 maintainers:
   - name: heshamMassoud

--- a/charts/public-service/README.md
+++ b/charts/public-service/README.md
@@ -65,6 +65,7 @@ The chart can be customized using the following configurable parameters:
 | `updateStrategy.rollingUpdate.maxUnavailable` | maximum number of Pods that can be unavailable during the update process. | `0` |
 | `minReadySeconds` | minimum number of seconds for which a newly created Pod should be ready without any of its containers crashing, for it to be considered available. | `5` |
 | `resources` | resource requests and limits | `{}` |
+| `affinity.enabled` | if true, pods will be on different nodes | `false` |
 | `nonSensitiveEnvs` | non sensitive environment variables | `{}` |
 | `sensitiveEnvs` | sensitive environment variables | `{}` |
 | `ingress.path` | enables Ingress | `false` |

--- a/charts/public-service/templates/deployment.yaml
+++ b/charts/public-service/templates/deployment.yaml
@@ -24,6 +24,18 @@ spec:
       annotations:
         checksum/config: {{ include (print $.Template.BasePath "/secrets.yaml") . | sha256sum }}
     spec:
+      {{- if .Values.affinity.enabled }}
+      affinity:
+        podAntiAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            - labelSelector:
+                matchExpressions:
+                  - key: app
+                    operator: In
+                    values:
+                      - {{ template "public-service.name" . }}
+              topologyKey: "kubernetes.io/hostname"
+      {{- end }}
       containers:
       - name: {{ .Chart.Name }}
         image: {{ .Values.image.repository }}:{{ .Values.image.tag }}

--- a/charts/public-service/values.yaml
+++ b/charts/public-service/values.yaml
@@ -78,3 +78,7 @@ readinessProbe:
   timeoutSeconds: 5
   successThreshold: 1
   failureThreshold: 5
+
+## enable/disable affinity rules for k8 component scheduling
+affinity:
+  enabled: false


### PR DESCRIPTION
## Description

New affinity flag introduced which can schedule pods on different nodes for higher reliability of the systems.