### PR TITLE
Configurable backoffLimit for cronjob chart.

### DIFF
--- a/charts/cronjob/Chart.yaml
+++ b/charts/cronjob/Chart.yaml
@@ -1,6 +1,4 @@
 apiVersion: v1
 description: Helm chart for deploying an instance of a cronjob on a K8s cluster.
 name: cronjob
-version: 1.6.0
-maintainers:
-  - name: heshamMassoud
+version: 1.7.0

--- a/charts/cronjob/README.md
+++ b/charts/cronjob/README.md
@@ -70,7 +70,7 @@ The chart can be customized using the following configurable parameters:
 | `externalConfig.configFileName` | Name of the external config file, which can be supplied to the cronjob | config.json |
 | `externalConfig.content` | Any file content that will be supplied to the cronjob | { "your": "content" } |
 | `activeDeadlineSeconds` | Set an active deadline for a pod in a job. See [k8s docs](https://kubernetes.io/docs/concepts/workloads/controllers/job/#job-termination-and-cleanup) for more info. | |
-
+| `backoffLimit` | By default, a Job runs uninterrupted unless there is a failure, at which point the Job defers to the `backoffLimit`. The `backoffLimit` field specifies the number of retries before marking the job as failed. | 6 |
 
 Specify parameters using `--set key=value[,key=value]` argument to `helm install`
 

--- a/charts/cronjob/README.md
+++ b/charts/cronjob/README.md
@@ -70,7 +70,7 @@ The chart can be customized using the following configurable parameters:
 | `externalConfig.configFileName` | Name of the external config file, which can be supplied to the cronjob | config.json |
 | `externalConfig.content` | Any file content that will be supplied to the cronjob | { "your": "content" } |
 | `activeDeadlineSeconds` | Set an active deadline for a pod in a job. See [k8s docs](https://kubernetes.io/docs/concepts/workloads/controllers/job/#job-termination-and-cleanup) for more info. | |
-| `backoffLimit` | By default, a Job runs uninterrupted unless there is a failure, at which point the Job defers to the `backoffLimit`. The `backoffLimit` field specifies the number of retries before marking the job as failed. | 6 |
+| `backoffLimit` | By default, a job runs uninterrupted unless there is a failure, at which point the job defers to the `backoffLimit`. The `backoffLimit` field specifies the number of retries before marking the job as failed. | 6 |
 
 Specify parameters using `--set key=value[,key=value]` argument to `helm install`
 
@@ -79,4 +79,3 @@ Alternatively a YAML file that specifies the values for the parameters can be pr
 ```bash
 $ helm upgrade --install my-cronjob --namespace cronjobs -f values.yaml .
 ```
-

--- a/charts/cronjob/templates/cronjob.yaml
+++ b/charts/cronjob/templates/cronjob.yaml
@@ -8,6 +8,7 @@ metadata:
     release: {{ .Release.Name }}
     heritage: {{ .Release.Service }}
 spec:
+  backoffLimit: {{ .Values.backoffLimit }}
   schedule: {{ .Values.schedule | quote }}
   {{- if .Values.runOnDemandOnly }}
   suspend: true

--- a/charts/cronjob/values.yaml
+++ b/charts/cronjob/values.yaml
@@ -60,3 +60,6 @@ externalConfig:
     {
       "your": "content"
     }
+
+# The backoffLimit field specifies the number of retries before marking the job as failed; the default value is 6.
+backoffLimit: 6

--- a/charts/logentries/Chart.yaml
+++ b/charts/logentries/Chart.yaml
@@ -7,5 +7,3 @@ appVersion: 0.2.1
 home: https://github.com/rapid7/docker-logentries
 sources:
   - https://github.com/rapid7/docker-logentries
-maintainers:
-  - name: heshamMassoud

--- a/charts/logentries/Chart.yaml
+++ b/charts/logentries/Chart.yaml
@@ -2,7 +2,7 @@ name: logentries
 apiVersion: v1
 description: Helm chart for deploying an instance of logentries as a DaemonSet on all nodes of a K8s cluster.
 icon: https://d1cnss1t6ao97n.cloudfront.net/mstatic/3eb3f9c/content/uploads/2015/10/logentries-logo.png
-version: 1.2.3
+version: 1.2.4
 appVersion: 0.2.1
 home: https://github.com/rapid7/docker-logentries
 sources:

--- a/charts/public-service/Chart.yaml
+++ b/charts/public-service/Chart.yaml
@@ -1,4 +1,4 @@
 apiVersion: v1
 name: public-service
 description: Helm chart for deploying an instance of a publicly available service on a K8s cluster (via HTTP from outside the cluster).
-version: 1.0.10
+version: 1.0.11

--- a/charts/public-service/Chart.yaml
+++ b/charts/public-service/Chart.yaml
@@ -2,5 +2,3 @@ apiVersion: v1
 name: public-service
 description: Helm chart for deploying an instance of a publicly available service on a K8s cluster (via HTTP from outside the cluster).
 version: 1.0.10
-maintainers:
-  - name: heshamMassoud


### PR DESCRIPTION
In default, when the running pod failures, the job retries itself and restarts 6 times. For some scenarios it might be useful to change this restart amount with config.