### PR TITLE
Use new version for cronjob

### DIFF
--- a/charts/cronjob/Chart.yaml
+++ b/charts/cronjob/Chart.yaml
@@ -1,4 +1,4 @@
 apiVersion: v1
 description: Helm chart for deploying an instance of a cronjob on a K8s cluster.
 name: cronjob
-version: 1.8.8
+version: 1.8.0

--- a/charts/cronjob/Chart.yaml
+++ b/charts/cronjob/Chart.yaml
@@ -1,4 +1,4 @@
 apiVersion: v1
 description: Helm chart for deploying an instance of a cronjob on a K8s cluster.
 name: cronjob
-version: 1.7.1
+version: 1.8.8

--- a/charts/cronjob/templates/cronjob.yaml
+++ b/charts/cronjob/templates/cronjob.yaml
@@ -1,4 +1,4 @@
-apiVersion: batch/v1beta1
+apiVersion: batch/v1
 kind: CronJob
 metadata:
   name: {{ template "cronjob.fullname" . }}


### PR DESCRIPTION
Problem: since k8s v1.25 the API version for cronjobs is changed: https://kubernetes.io/docs/reference/using-api/deprecation-guide/#cronjob-v125