### PR TITLE
update api-versions for public services.

### DIFF
--- a/charts/public-service/Chart.yaml
+++ b/charts/public-service/Chart.yaml
@@ -1,4 +1,4 @@
 apiVersion: v1
 name: public-service
 description: Helm chart for deploying an instance of a publicly available service on a K8s cluster (via HTTP from outside the cluster).
-version: 1.0.11
+version: 1.1.0

--- a/charts/public-service/templates/ingress.yaml
+++ b/charts/public-service/templates/ingress.yaml
@@ -1,7 +1,7 @@
 {{- if .Values.ingress.enabled -}}
 {{- $fullName := include "public-service.fullname" . -}}
 {{- $ingressPath := .Values.ingress.path -}}
-apiVersion: networking.k8s.io/v1beta1
+apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
   name: {{ $fullName }}
@@ -31,9 +31,12 @@ spec:
       http:
         paths:
           - path: {{ $ingressPath }}
+            pathType: ImplementationSpecific
             backend:
-              serviceName: {{ $fullName }}
-              servicePort: service-port
+              service:
+                name: {{ $fullName }}
+                port: 
+                  name: service-port
   {{- end }}
   # If no hosts are defined, a default path for the backend mapping has to be defined
   {{- if not  .Values.ingress.hosts }}
@@ -41,8 +44,10 @@ spec:
         paths:
           - path: {{ $ingressPath }}
             backend:
-              serviceName: {{ $fullName }}
-              servicePort: service-port
+              service:
+                name: {{ $fullName }}
+                port: 
+                  name: service-port
 
 {{- end }}
 {{- end }}

--- a/charts/public-service/templates/ingress.yaml
+++ b/charts/public-service/templates/ingress.yaml
@@ -43,6 +43,7 @@ spec:
     - http:
         paths:
           - path: {{ $ingressPath }}
+            pathType: ImplementationSpecific
             backend:
               service:
                 name: {{ $fullName }}

--- a/charts/public-service/templates/managedCertificate.yaml
+++ b/charts/public-service/templates/managedCertificate.yaml
@@ -1,5 +1,5 @@
 {{- if .Values.managecertificate.enabled -}}
-apiVersion: networking.gke.io/v1beta2
+apiVersion: networking.gke.io/v1
 kind: ManagedCertificate
 metadata:
   name: {{ .Values.managecertificate.name }}

--- a/charts/public-service/templates/poddisruptionbudgets.yaml
+++ b/charts/public-service/templates/poddisruptionbudgets.yaml
@@ -1,6 +1,6 @@
 {{- if .Values.pdb.enabled -}}
 {{- $fullName := include "public-service.fullname" . -}}
-apiVersion: policy/v1beta1
+apiVersion: policy/v1
 kind: PodDisruptionBudget
 metadata:
   name: {{ $fullName }}


### PR DESCRIPTION
In this pr the API-versions of charts for Ingresses,certificates and PodDisruptionBudget were updated
Documentation: 
https://cloud.google.com/kubernetes-engine/docs/deprecations/apis-1-22?_ga=2.88859483.-158131741.1641850276#ingress-v122